### PR TITLE
Manual app locking without NFC tag

### DIFF
--- a/Locked/AppLocker.swift
+++ b/Locked/AppLocker.swift
@@ -35,13 +35,38 @@ class AppLocker: ObservableObject {
         }
     }
     
-    func toggleLocking(for profile: Profile) {
+    func startSessionWithNFC(for profile: Profile) {
         guard isAuthorized else {
             print("Not authorized to lock apps")
             return
         }
+        guard isLocking == false else { return }
         
-        isLocking.toggle()
+        isLocking = true
+        saveLockingState()
+        applyLockingSettings(for: profile)
+    }
+    
+    func startSessionManually(for profile: Profile) {
+        guard isAuthorized else {
+            print("Not authorized to lock apps")
+            return
+        }
+        guard isLocking == false else { return }
+        
+        isLocking = true
+        saveLockingState()
+        applyLockingSettings(for: profile)
+    }
+
+    func endSession(for profile: Profile) {
+        guard isAuthorized else {
+            print("Not authorized to unlock apps")
+            return
+        }
+        guard isLocking == true else { return }
+        
+        isLocking = false
         saveLockingState()
         applyLockingSettings(for: profile)
     }


### PR DESCRIPTION
Hi,

I thought it'd be useful to be able to start a session in the app without needing an NFC tag (you will still need a tag to unlock apps again)

Like last time, I haven't been able to test this out on a physical device because of the XCode team setup. Would you be able to test this out for me and let me know what you think?

Thanks!