### PR TITLE
Restrict 'Lock Without NFC' to users who have used NFC before

### DIFF
--- a/Locked/AppLocker.swift
+++ b/Locked/AppLocker.swift
@@ -13,9 +13,11 @@ class AppLocker: ObservableObject {
     let store = ManagedSettingsStore()
     @Published var isLocking = false
     @Published var isAuthorized = false
-    
+    @Published var hasUsedNFC = false
+
     init() {
         loadLockingState()
+        loadNFCUsageState()
         Task {
             await requestAuthorization()
         }
@@ -41,7 +43,13 @@ class AppLocker: ObservableObject {
             return
         }
         guard isLocking == false else { return }
-        
+
+        // Record that the user has successfully used NFC
+        if !hasUsedNFC {
+            hasUsedNFC = true
+            saveNFCUsageState()
+        }
+
         isLocking = true
         saveLockingState()
         applyLockingSettings(for: profile)
@@ -96,8 +104,16 @@ class AppLocker: ObservableObject {
     private func loadLockingState() {
         isLocking = UserDefaults.standard.bool(forKey: "isLocking")
     }
-    
+
     private func saveLockingState() {
         UserDefaults.standard.set(isLocking, forKey: "isLocking")
+    }
+
+    private func loadNFCUsageState() {
+        hasUsedNFC = UserDefaults.standard.bool(forKey: "hasUsedNFC")
+    }
+
+    private func saveNFCUsageState() {
+        UserDefaults.standard.set(hasUsedNFC, forKey: "hasUsedNFC")
     }
 }

--- a/Locked/LockedView.swift
+++ b/Locked/LockedView.swift
@@ -118,7 +118,7 @@ struct LockedView: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(height: geometry.size.height / 3)
             }
-            if !isLocking {
+            if !isLocking && appLocker.hasUsedNFC {
                 Button("Lock Without NFC") {
                     showStartSessionWarning = true
                 }

--- a/Locked/LockedView.swift
+++ b/Locked/LockedView.swift
@@ -166,7 +166,7 @@ struct LockedView: View {
         Button(action: {
             showCreateTagAlert = true
         }) {
-            Text("New Lock")
+            Text("Register Tag")
                 .bold()
                 .foregroundColor(.white)
         }


### PR DESCRIPTION
Hey 👋🏻

Just another tiny idea I had based on https://github.com/BuckDenver/Locked/pull/3

"Lock without NFC" feels a bit dangerous if the user has never started a session via an NFC tag before